### PR TITLE
Adds support to export scripts inside page nodes

### DIFF
--- a/amtree.sh
+++ b/amtree.sh
@@ -336,6 +336,13 @@ function exportTree {
                 local PAGENODE=$(curl -s -k -X GET -H "Accept-API-Version:resource=1.0" -H "X-Requested-With:XmlHttpRequest" -H "iPlanetDirectoryPro:$AMSESSION" $AM/json${REALM}/realm-config/authentication/authenticationtrees/nodes/$PAGENODETYPE/$PAGENODEID | jq '. | del (._rev)')
                 1>&2 echo -n "."
                 EXPORTS=$(echo $EXPORTS "{ \"innernodes\": { \"$PAGENODEID\": $PAGENODE } }" | jq -s 'reduce .[] as $item ({}; . * $item)')
+                
+                # Export scripts inside page nodes
+                if [ "$PAGENODETYPE" == "ScriptedDecisionNode" ]; then
+                    local SCRIPTID=$(echo $PAGENODE | jq -r '.script')
+                    local SCRIPT=$(curl -s -k -X GET -H "Accept-API-Version:resource=1.0" -H "X-Requested-With:XmlHttpRequest" -H "iPlanetDirectoryPro:$AMSESSION" $AM/json${REALM}/scripts/$SCRIPTID | jq '. | del (._rev)')
+                    EXPORTS=$(echo $EXPORTS "{ \"scripts\": { \"$SCRIPTID\": $SCRIPT } }" | jq -s 'reduce .[] as $item ({}; . * $item)')
+                fi
             done
         fi
         # Export Scripts


### PR DESCRIPTION
Scripted decision nodes can reside inside page nodes.  For example, SDK users coding against AM 6.5 can write scripts to add metadata callbacks to inform their UI which step is current in an authentication tree.