### PR TITLE
Added bad hostname check

### DIFF
--- a/amtree.sh
+++ b/amtree.sh
@@ -40,11 +40,16 @@ function login {
     fi
     shopt -u nocasematch
     RESPONSE=$(curl -j -c cookies.txt -s -k -i -X POST -H "Accept-API-Version:resource=1.0" -H "X-Requested-With:XmlHttpRequest" -H "X-OpenAM-Username:${AMADMIN}" -H "X-OpenAM-Password:${AMPASSWD}" "$AM/json/authenticate")
-    if [ "null" == "$(echo "$RESPONSE" | sed -n -e 's/^.*{"/{"/p' | jq .tokenId)" ] ; then
-        1>&2 echo "Error: $(echo "$RESPONSE" | sed -n -e 's/^.*{"/{"/p' | jq -r '.errorMessage')"
+    if [[ $RESPONSE = "" ]]; then
+        echo 'Error: Check hostname is valid.'
         exit -1
     else
-        AMSESSION=$(echo "$RESPONSE" | sed -n -e 's/^.*{"/{"/p' | jq .tokenId | sed -e 's/\"//g')
+        if [ "null" == "$(echo "$RESPONSE" | sed -n -e 's/^.*{"/{"/p' | jq .tokenId)" ]; then
+                1>&2 echo "Error: $(echo "$RESPONSE" | sed -n -e 's/^.*{"/{"/p' | jq -r '.errorMessage')"
+                exit -1
+        else
+                AMSESSION=$(echo "$RESPONSE" | sed -n -e 's/^.*{"/{"/p' | jq .tokenId | sed -e 's/\"//g')
+        fi
     fi
     setVersion
 }


### PR DESCRIPTION
AM-treetool ±|add-bad-hostname-check|→ ./amtree.sh -h https://openam-tenant-dev.forgeblocks.com/am -u chico.demetroff@@forgerock.com -p 'Frdp-2010' -r  /alpha -s
Error: Check hostname is valid.

Adds check for when hostname is not valid and exits script.